### PR TITLE
Prevent slide animation after release

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -294,6 +294,9 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
         return;
       }
     }
+    if (!activeKey) {
+      anim.setValue(0)
+    }
     setIsOffset(false);
   }, [activeKey, index, panIndex, key, activeIndex]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -295,7 +295,7 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
       }
     }
     if (!activeKey) {
-      anim.setValue(0)
+      anim.setValue(0);
     }
     setIsOffset(false);
   }, [activeKey, index, panIndex, key, activeIndex]);


### PR DESCRIPTION
Right now offsetted cells slide once more after you release. This change will snap them into place instead, which looks a bit better 🙂