### PR TITLE
fix: Android now works

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -32,7 +32,7 @@
       }
     },
     "..": {
-      "version": "1.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-native-draglist",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "FlatList that reorders items by dragging",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.tsx",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "echo \"YOLO! What could possibly go wrong?\" && exit 1",
+    "test": "echo \"YOLO! What could possibly go wrong? (On a serious note, please run both iOS and Android examples and drag things around).\" && exit 1",
     "build": "microbundle-crl --no-compress --format modern,cjs",
     "prepare": "npm run build",
     "release": "release-it"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -316,9 +316,7 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
       onLayout(evt);
     }
 
-    ref.current?.measure((x, y, width, height) => {
-      layouts[key] = { x, y, width, height };
-    });
+    layouts[key] = { ...evt.nativeEvent.layout };
   }
 
   return (


### PR DESCRIPTION
Turns out it's [a bug from React Native](https://github.com/facebook/react-native/issues/4753) with `measure()`. We now use `LayoutChangeEvent`'s own rectangle instead of `measure()`.

Fixes #4 