### PR TITLE
Disable FlatList scroll while dragging

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -242,6 +242,7 @@ export default function DragList<T>(props: Props<T>) {
           renderItem={renderDragItem}
           CellRendererComponent={CellRendererComponent}
           extraData={extra}
+          scrollEnabled={!activeKey.current}
           onScroll={onDragScroll}
           scrollEventThrottle={16} // From react-native-draggable-flatlist; no idea why.
           removeClippedSubviews={false} // https://github.com/facebook/react-native/issues/18616


### PR DESCRIPTION
I found this problem where sometimes instead of moving the item, the list scrolls.
![ScrollBug](https://user-images.githubusercontent.com/110995715/218994767-e33a00c6-8d75-4702-b735-2436bd25f4e3.gif)

I managed to solve it by disabling the scroll on the FlatList while we have an activeKey.
