### PR TITLE
fix: update y position upon panResponderGrant to capture list position on screen

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,7 @@ export default function DraggableLyrics() {
       .map(num => SOUND_OF_SILENCE.map(word => `${word}${num}`))
       .flat(),
   );
+  const [scrollViewHeight, setScrollViewHeight] = useState(250);
   const listRef = React.useRef<FlatList<string>>(null);
 
   function keyExtractor(str: string) {
@@ -64,17 +65,24 @@ export default function DraggableLyrics() {
         renderItem={renderItem}
       />
       <Text style={styles.header}>Auto-Scrolling List</Text>
-      <DragList
-        style={styles.scrolledList}
-        ref={listRef} // Verify that using the ref works
-        data={scrollData}
-        keyExtractor={keyExtractor}
-        onReordered={onScrollReordered}
-        renderItem={renderItem}
-      />
+      <View style={{height: scrollViewHeight}}>
+        <DragList
+          style={styles.scrolledList}
+          ref={listRef} // Verify that using the ref works
+          data={scrollData}
+          keyExtractor={keyExtractor}
+          onReordered={onScrollReordered}
+          renderItem={renderItem}
+          onLayout={() => console.log('View is laying out again!')}
+        />
+      </View>
       <Button
         onPress={() => listRef.current?.scrollToIndex({index: 0})}
         title="Scroll to Top"
+      />
+      <Button
+        onPress={() => setScrollViewHeight(scrollViewHeight + 50)}
+        title="Add 50px to ScrollView Height"
       />
     </View>
   );
@@ -105,6 +113,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'yellow',
   },
   scrolledList: {
-    height: 300,
+    //    height: 300,
   },
 });

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,7 +18,6 @@ export default function DraggableLyrics() {
       .map(num => SOUND_OF_SILENCE.map(word => `${word}${num}`))
       .flat(),
   );
-  const [scrollViewHeight, setScrollViewHeight] = useState(250);
   const listRef = React.useRef<FlatList<string>>(null);
 
   function keyExtractor(str: string) {
@@ -65,24 +64,17 @@ export default function DraggableLyrics() {
         renderItem={renderItem}
       />
       <Text style={styles.header}>Auto-Scrolling List</Text>
-      <View style={{height: scrollViewHeight}}>
-        <DragList
-          style={styles.scrolledList}
-          ref={listRef} // Verify that using the ref works
-          data={scrollData}
-          keyExtractor={keyExtractor}
-          onReordered={onScrollReordered}
-          renderItem={renderItem}
-          onLayout={() => console.log('View is laying out again!')}
-        />
-      </View>
+      <DragList
+        style={styles.scrolledList}
+        ref={listRef} // Verify that using the ref works
+        data={scrollData}
+        keyExtractor={keyExtractor}
+        onReordered={onScrollReordered}
+        renderItem={renderItem}
+      />
       <Button
         onPress={() => listRef.current?.scrollToIndex({index: 0})}
         title="Scroll to Top"
-      />
-      <Button
-        onPress={() => setScrollViewHeight(scrollViewHeight + 50)}
-        title="Add 50px to ScrollView Height"
       />
     </View>
   );
@@ -113,6 +105,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'yellow',
   },
   scrolledList: {
-    //    height: 300,
+    height: 300,
   },
 });

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -32,7 +32,7 @@
       }
     },
     "..": {
-      "version": "3.0.0",
+      "version": "3.4.0",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,6 +107,17 @@ function DragListImpl<T>(
       onPanResponderGrant: (_, gestate) => {
         pan.setValue(gestate.dy);
         panGrantedRef.current = true;
+
+        flatWrapRef.current?.measureInWindow((x, y) => {
+          // Capture the latest y position upon starting a drag, because the
+          // window could have moved since we last measured. Remember that moves
+          // without resizes _don't_ generate onLayout, so we need to actively
+          // measure here. React doesn't give a way to subscribe to move events.
+          // We don't overwrite width/height from this measurement because
+          // height can come back 0.
+          flatWrapLayout.current = { ...flatWrapLayout.current, x, y };
+        });
+
         onDragBegin?.();
       },
       onPanResponderMove: (_, gestate) => {
@@ -251,7 +262,10 @@ function DragListImpl<T>(
 
   const onDragLayout = useCallback(
     (evt: LayoutChangeEvent) => {
+      console.log("onDragLayout");
       flatWrapRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+        // Even though we capture x/y during onPanResponderGrant, we still
+        // capture height here because measureInWindow can return 0 height.
         flatWrapLayout.current = { x: pageX, y: pageY, width, height };
       });
       if (onLayout) {
@@ -260,7 +274,6 @@ function DragListImpl<T>(
     },
     [onLayout]
   );
-
   return (
     <DragListProvider
       activeKey={activeKey.current}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -262,7 +262,6 @@ function DragListImpl<T>(
 
   const onDragLayout = useCallback(
     (evt: LayoutChangeEvent) => {
-      console.log("onDragLayout");
       flatWrapRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
         // Even though we capture x/y during onPanResponderGrant, we still
         // capture height here because measureInWindow can return 0 height.


### PR DESCRIPTION
onLayout is not sent during moves, only during resizes, and so we need to update the y position to the latest whenever you begin dragging.