### PR TITLE
events can receive a void callback

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,8 +72,8 @@ interface Props<T> extends Omit<FlatListProps<T>, "renderItem"> {
   containerStyle?: StyleProp<ViewStyle>;
   onDragBegin?: () => void;
   onDragEnd?: () => void;
-  onHoverChanged?: (hoverIndex: number) => Promise<void>;
-  onReordered?: (fromIndex: number, toIndex: number) => Promise<void>;
+  onHoverChanged?: (hoverIndex: number) => Promise<void> | void;
+  onReordered?: (fromIndex: number, toIndex: number) => Promise<void> | void;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onLayout?: (e: LayoutChangeEvent) => void;
 }


### PR DESCRIPTION
- ~~Expose the DataList props, for typing~~
- Do not require a promise for onHoverChanged and onReordered.


~~No idea why `ForwardRefFn` makes the component loose all typing,~~

![image](https://github.com/fivecar/react-native-draglist/assets/23088305/f132e42b-4c09-4bc6-9175-711a7a34677a)


~~However, if you expose the DataList props, we can pass it back to the component along with our data type to fix it, see the changes in ReadMe.~~