### PR TITLE
Use measure instead of measureInWindow to get screen coordinate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,7 +127,7 @@ function DragListImpl<T>(props: Props<T>) {
         pan.setValue(gestate.dy);
         panGrantedRef.current = true;
 
-        flatWrapRef.current?.measureInWindow((x, y) => {
+        flatWrapRef.current?.measure((x, y) => {
           // Capture the latest y position upon starting a drag, because the
           // window could have moved since we last measured. Remember that moves
           // without resizes _don't_ generate onLayout, so we need to actively

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,14 +127,18 @@ function DragListImpl<T>(props: Props<T>) {
         pan.setValue(gestate.dy);
         panGrantedRef.current = true;
 
-        flatWrapRef.current?.measure((x, y) => {
+        flatWrapRef.current?.measure((pageX, pageY) => {
           // Capture the latest y position upon starting a drag, because the
           // window could have moved since we last measured. Remember that moves
           // without resizes _don't_ generate onLayout, so we need to actively
           // measure here. React doesn't give a way to subscribe to move events.
           // We don't overwrite width/height from this measurement because
           // height can come back 0.
-          flatWrapLayout.current = { ...flatWrapLayout.current, x, y };
+          flatWrapLayout.current = {
+            ...flatWrapLayout.current,
+            x: pageX,
+            y: pageY,
+          };
         });
 
         onDragBegin?.();


### PR DESCRIPTION
On android, when dragging, the item is placed around 50px below the touch point.
The reason is that: we use the measureInWindow which does not really return screencoordinate.

