### PR TITLE
Add simple support for horizontal lists

### DIFF
--- a/src/DragListContext.tsx
+++ b/src/DragListContext.tsx
@@ -17,6 +17,7 @@ type ContextProps<T> = {
   pan: Animated.Value;
   panIndex: number;
   layouts: LayoutCache;
+  horizontal: boolean | null | undefined;
   children: React.ReactNode;
 };
 
@@ -33,11 +34,12 @@ export function DragListProvider<T>({
   pan,
   panIndex,
   layouts,
+  horizontal,
   children,
 }: ContextProps<T>) {
   const value = useMemo(
-    () => ({ activeKey, activeIndex, keyExtractor, pan, panIndex, layouts }),
-    [activeKey, activeIndex, keyExtractor, pan, panIndex, layouts],
+    () => ({ activeKey, activeIndex, keyExtractor, pan, panIndex, layouts, horizontal }),
+    [activeKey, activeIndex, keyExtractor, pan, panIndex, layouts, horizontal],
   );
 
   return (


### PR DESCRIPTION
This adds a support for "horizontal" lists (requested in https://github.com/fivecar/react-native-draglist/issues/29) like this:
```
<DragList
  horizontal={true}
  data={data}
  keyExtractor={keyExtractor}
  renderItem={renderItem}
  onReordered={onReordered}
/>
```
I know that the implementation is not elegant in the slightest, but I'm not a TypeScript or React developer and I just wanted to make it work _somehow_, which it does.

If someone can make the implementation more generic, it would be great.

The change with `function DragListImpl<T>(props: Props<T>, reference: React.ForwardedRef<FlatList<T>>)` is indended to get rid of the error message:
`Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?`