### PR TITLE
fix: block rapid reordering from using stale indices

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -70,6 +70,16 @@ export default function DraggableLyrics() {
         data={scrollData}
         keyExtractor={keyExtractor}
         onReordered={onScrollReordered}
+        ListHeaderComponent={() => (
+          <View>
+            <Text>Drag my header</Text>
+          </View>
+        )}
+        ListFooterComponent={() => (
+          <View>
+            <Text>Drag my footer</Text>
+          </View>
+        )}
         renderItem={renderItem}
       />
       <Button

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -32,7 +32,7 @@
       }
     },
     "..": {
-      "version": "3.4.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",


### PR DESCRIPTION
Not sure this is absolutely necessary, but it prevents people from rapidly reordering things so quickly that stale indices are used.