### PR TITLE
Revert "fix: remove typescript bypass on forwardRef (#31)"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Animated,
   Easing,
@@ -79,12 +79,12 @@ interface Props<T> extends Omit<FlatListProps<T>, "renderItem"> {
 }
 
 function DragListImpl<T>(
-  props: Props<T> & { ref: React.ForwardedRef<FlatList<T>> }
+  props: Props<T>,
+  ref?: React.ForwardedRef<FlatList<T>> | null
 ) {
   const {
     containerStyle,
     data,
-    ref,
     keyExtractor,
     onDragBegin,
     onDragEnd,
@@ -476,6 +476,12 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
   );
 }
 
-const DragList = forwardRef<FlatList<any>, Props<any>>((props, ref) => <DragListImpl {...props} ref={ref} />);
+declare module "react" {
+  function forwardRef<T, P = {}>(
+    render: (props: P, ref: React.Ref<T>) => React.ReactNode | null
+  ): (props: P & React.RefAttributes<T>) => JSX.Element | null;
+}
+
+const DragList = React.forwardRef(DragListImpl);
 
 export default DragList;


### PR DESCRIPTION
This reverts #31, which began to cause warnings and issues in React Native (because function components can't take a ref).

We then update how we handle the refs in Typescript so that there are no Typescript errors when you use the component. Verified working via example app.