### PR TITLE
fix: Refactor onStartDrag and onEndDrag to not require parameters

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,13 +44,13 @@ export interface DragListRenderItemInfo<T> extends ListRenderItemInfo<T> {
    * @deprecated Use onDragStart instead
    * @see onDragStart
    */
-  onStartDrag: () => void;
+  onStartDrag?: () => void;
 
   /**
    * @deprecated Use onDragEnd instead
    * @see onDragEnd
    */
-  onEndDrag: () => void;
+  onEndDrag?: () => void;
 
   /**
    * Whether the item is being dragged at the moment.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -476,12 +476,6 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
   );
 }
 
-declare module "react" {
-  function forwardRef<T, P = {}>(
-    render: (props: P, ref: React.Ref<T>) => React.ReactNode | null
-  ): (props: P & React.RefAttributes<T>) => JSX.Element | null;
-}
-
 const DragList = React.forwardRef(DragListImpl);
 
 export default DragList;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "module": "ES2015",
     "noEmit": false,
-    "jsx": "react",
+    "jsx": "preserve",
     "skipLibCheck": true,
     "types": []
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "strict": true,
     "module": "ES2015",
     "noEmit": false,
-    "jsx": "preserve",
     "skipLibCheck": true,
     "types": []
   },


### PR DESCRIPTION
In the situation below, onStartDrag and onEndDrag are still required despite being deprecated, causing issues that need to be addressed.

```ts
<DragList
          data={inputResult}
          ref={scrollRef}
          keyboardShouldPersistTaps="always"
          onReordered={(from, to) => {
            ...
          }}
          keyExtractor={(item) => item.id}
          renderItem={(data) => (
            <RenderOrderList
              ref={inputRef}
              separators={data.separators}
              index={data.index}
              isActive={data.isActive}
              item={data.item}
              // need to use onStartDrag & onEndDrag even being deprecated
              onDragEnd={data.onDragEnd}
              onDragStart={data.onDragStart}
            />
          )}
        />
```