### PR TITLE
add index to keyExtractor

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ interface ExtraData {
 
 interface Props<T> extends Omit<FlatListProps<T>, "renderItem"> {
   data: T[];
-  keyExtractor: (item: T) => string;
+  keyExtractor: (item: T, index: number) => string;
   renderItem: (info: DragListRenderItemInfo<T>) => React.ReactElement | null;
   containerStyle?: StyleProp<ViewStyle>;
   onDragBegin?: () => void;
@@ -191,7 +191,7 @@ function DragListImpl<T>(
           while (
             curIndex < dataRef.current.length &&
             layouts.hasOwnProperty(
-              (key = keyExtractor(dataRef.current[curIndex]))
+              (key = keyExtractor(dataRef.current[curIndex], curIndex))
             ) &&
             layouts[key].pos + layouts[key].extent < clientPos
           ) {
@@ -260,7 +260,7 @@ function DragListImpl<T>(
 
   const renderDragItem = useCallback(
     (info: ListRenderItemInfo<T>) => {
-      const key = keyExtractor(info.item);
+      const key = keyExtractor(info.item, info.index);
       const isActive = key === activeKey.current;
       const onDragStart = () => {
         // We don't allow dragging for lists less than 2 elements


### PR DESCRIPTION
This allows the index to be used in keyExtractor, like FlashList does, which fixes issues with multiple of the same item in data.