### PR TITLE
fix: #25 - scroll equally fast downward

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -165,18 +165,15 @@ function DragListImpl<T>(
           // can be a bit finnicky. You need to consider client coordinates and
           // coordinates relative to the screen.
           if (leadingEdge < 0) {
-            offset =
-              scrollPos.current >= dragItemExtent
-                ? -dragItemExtent
-                : -scrollPos.current;
+            offset = -dragItemExtent;
           } else if (trailingEdge > flatWrapLayout.current.extent) {
-            offset = scrollPos.current + dragItemExtent;
+            offset = dragItemExtent;
           }
 
           if (offset !== 0) {
             flatRef.current?.scrollToOffset({
               animated: true,
-              offset: scrollPos.current + offset,
+              offset: Math.max(0, scrollPos.current + offset),
             });
           }
 


### PR DESCRIPTION
We calculated downward scrolling incorrectly, so would auto-scroll more in a single hop as you dragged items further down in a scrolling list. This normalizes the scroll speed to be the same in both directions.