### PR TITLE
fix: maintain elevation on all active items

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -456,7 +456,7 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
     () =>
       isActive
         ? { elevation: new Animated.Value(1), zIndex: new Animated.Value(999) }
-        : { elevation: 0, zIndex: 0 },
+        : { elevation: new Animated.Value(0), zIndex: new Animated.Value(0) },
     [isActive]
   );
 


### PR DESCRIPTION
It turns out if you set elevation to non-Animated values, those views will permanently not have changeable elevations. Seems like a bug in the React Native library, introduced in 0.76.3 (or thereabouts). This now conforms all settings of elevation and zindex to Animated values.