### PR TITLE
fix: #68 - forwardRef declaration

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -37,7 +37,7 @@
       }
     },
     "..": {
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",
@@ -45,7 +45,7 @@
         "@types/jest": "^29.2.3",
         "@types/react": "^18.2.6",
         "microbundle-crl": "^0.13.11",
-        "react": "^18.1.0",
+        "react": "^18.3.1",
         "react-native": "^0.76.3",
         "release-it": "^15.5.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/jest": "^29.2.3",
         "@types/react": "^18.2.6",
         "microbundle-crl": "^0.13.11",
-        "react": "^18.1.0",
+        "react": "^18.3.1",
         "react-native": "^0.76.3",
         "release-it": "^15.5.1"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^29.2.3",
     "@types/react": "^18.2.6",
     "microbundle-crl": "^0.13.11",
-    "react": "^18.1.0",
+    "react": "^18.3.1",
     "react-native": "^0.76.3",
     "release-it": "^15.5.1"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -540,12 +540,8 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
   );
 }
 
-declare module "react" {
-  function forwardRef<T, P = {}>(
-    render: (props: P, ref: React.Ref<T>) => React.ReactNode | null
-  ): (props: P & React.RefAttributes<T>) => React.ReactNode | null;
-}
-
-const DragList = React.forwardRef(DragListImpl);
+const DragList = React.forwardRef(DragListImpl) as <T>(
+  props: Props<T> & { ref?: React.ForwardedRef<FlatList<T>> }
+) => React.ReactElement;
 
 export default DragList;


### PR DESCRIPTION
Removed the forwardRef declaration from the index.tsx and instead used a different approach to propagate types past the forwardRef (which otherwise removes the type inference/binding based on the data prop).