### PR TITLE
wip: #70 scrollable parent reordering

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,7 +1,8 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   Button,
   FlatList,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -11,15 +12,32 @@ import DragList, {DragListRenderItemInfo} from 'react-native-draglist';
 
 const SOUND_OF_SILENCE = ['hello', 'darkness', 'my', 'old', 'friend'];
 
+const ListHeader = () => (
+  <View>
+    <Text>Drag my header</Text>
+  </View>
+);
+
+const ListFooter = () => (
+  <View>
+    <Text>Drag my footer</Text>
+  </View>
+);
+
 export default function DraggableLyrics() {
   const [data, setData] = useState(SOUND_OF_SILENCE);
   const [scrollData, setScrollData] = useState(
-    Array(8, 6, 7, 5, 3, 0, 9)
+    [8, 6, 7, 5, 3, 0, 9]
       .map(num => SOUND_OF_SILENCE.map(word => `${word}${num}`))
       .flat(),
   );
   const [horzData, setHorzData] = useState(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
   const listRef = React.useRef<FlatList<string> | null>(null);
+  const scrollRef = React.useRef<ScrollView | null>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({y: 80, animated: true});
+  }, []);
 
   function keyExtractor(str: string) {
     return str;
@@ -64,7 +82,7 @@ export default function DraggableLyrics() {
   }
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container} ref={scrollRef} scrollEnabled={false}>
       <Text style={styles.header}>Basic List</Text>
       <DragList
         data={data}
@@ -75,20 +93,12 @@ export default function DraggableLyrics() {
       <Text style={styles.header}>Auto-Scrolling List</Text>
       <DragList
         style={styles.scrolledList}
-        ref={listRef} // Verify that using the ref works
+        ref={listRef}
         data={scrollData}
         keyExtractor={keyExtractor}
         onReordered={onScrollReordered}
-        ListHeaderComponent={() => (
-          <View>
-            <Text>Drag my header</Text>
-          </View>
-        )}
-        ListFooterComponent={() => (
-          <View>
-            <Text>Drag my footer</Text>
-          </View>
-        )}
+        ListHeaderComponent={ListHeader}
+        ListFooterComponent={ListFooter}
         renderItem={renderItem}
       />
       <Button
@@ -103,7 +113,18 @@ export default function DraggableLyrics() {
         onReordered={onReorderedHorz}
         renderItem={renderItem}
       />
-    </View>
+      <Text style={[styles.header, {marginTop: 128}]}>
+        Scroll-within-Scroll List
+      </Text>
+      <DragList
+        data={data}
+        keyExtractor={keyExtractor}
+        onReordered={onReordered}
+        ListHeaderComponent={ListHeader}
+        ListFooterComponent={ListFooter}
+        renderItem={renderItem}
+      />
+    </ScrollView>
   );
 }
 

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+ruby ">= 3.1.0"
  
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -37,7 +37,7 @@
       }
     },
     "..": {
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,14 +126,26 @@ function DragListImpl<T>(
   const pan = useRef(new Animated.Value(0)).current;
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponderCapture: () =>
-        !!activeKey.current && !reorderingRef.current,
-      onStartShouldSetPanResponder: () =>
-        !!activeKey.current && !reorderingRef.current,
-      onMoveShouldSetPanResponder: () =>
-        !!activeKey.current && !reorderingRef.current,
-      onMoveShouldSetPanResponderCapture: () =>
-        !!activeKey.current && !reorderingRef.current,
+      onStartShouldSetPanResponderCapture: () => {
+        const res = !!activeKey.current && !reorderingRef.current;
+        console.log("onStartShouldSetPanResponderCapture", res);
+        return res;
+      },
+      onStartShouldSetPanResponder: () => {
+        const res = !!activeKey.current && !reorderingRef.current;
+        console.log("onStartShouldSetPanResponder", res);
+        return res;
+      },
+      onMoveShouldSetPanResponder: () => {
+        const res = !!activeKey.current && !reorderingRef.current;
+        console.log("onMoveShouldSetPanResponder", res);
+        return res;
+      },
+      onMoveShouldSetPanResponderCapture: () => {
+        const res = !!activeKey.current && !reorderingRef.current;
+        console.log("onMoveShouldSetPanResponderCapture", res);
+        return res;
+      },
       onPanResponderGrant: (_, gestate) => {
         grantScrollPosRef.current = scrollPos.current;
         pan.setValue(0);


### PR DESCRIPTION
This tries to demo whether dragging works correctly when the parent is scrolled to a different position. Note that since we don't want the parent to capture the pan gesture, we actually disable the ScrollView from capturing, and manually scroll via a `useEffect` hook.

It doesn't seem #70 reproduces in this example. When dragging, everything looks correct, even the first time.