### PR TITLE
fix: #70 Timing fix for async measure call

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -37,7 +37,7 @@
       }
     },
     "..": {
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "devDependencies": {
         "@release-it/conventional-changelog": "^5.1.1",


### PR DESCRIPTION
Not positive this fixes #70, but there's at least one issue, which is that `measure()` calls its callback asynchronously, so some values relied on in several of the panResponder functions are incorrect if you perform them prior to the measurement being complete.

In particular, for #70, it's likely `grantActiveCenterOffsetRef.current` that ends up incorrect if you blow past the `measure()` too quickly.

This PR:
- Adds a `flatWrapRefPosUpdatedRef` to track whether the `measure()` callback has been called.
- Moves the `grantActiveCenterOffsetRef` calculation to after the `measure()` callback has been called.
- Skips processing onPanResponderMove if the `measure()` callback hasn't been called yet.