### PR TITLE
feat: #78 Keep `onHoverChanged` up to date

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -317,6 +317,11 @@ function DragListImpl<T>(
     dataRef.current = data;
   }, [data]);
 
+  // #78 - keep onHoverChanged up to date in our ref
+  useEffect(() => {
+    hoverRef.current = props.onHoverChanged;
+  }, [props.onHoverChanged]);
+
   useEffect(() => {
     reorderRef.current = props.onReordered;
   }, [props.onReordered]);


### PR DESCRIPTION
This keeps our ref up to date with property changes, which we really should have done all along.