### PR TITLE
fix: #76 Remove flicker on reorder

### DIFF
--- a/src/DragListContext.tsx
+++ b/src/DragListContext.tsx
@@ -23,6 +23,7 @@ type ContextProps<T> = {
   keyExtractor: (item: T, index: number) => string;
   pan: Animated.Value;
   panIndex: number;
+  panOpacity: Animated.Value;
   layouts: LayoutCache;
   horizontal: boolean | null | undefined;
   children: React.ReactNode;
@@ -40,13 +41,32 @@ export function DragListProvider<T>({
   keyExtractor,
   pan,
   panIndex,
+  panOpacity,
   layouts,
   horizontal,
   children,
 }: ContextProps<T>) {
   const value = useMemo(
-    () => ({ activeKey, activeIndex, keyExtractor, pan, panIndex, layouts, horizontal }),
-    [activeKey, activeIndex, keyExtractor, pan, panIndex, layouts, horizontal],
+    () => ({
+      activeKey,
+      activeIndex,
+      keyExtractor,
+      pan,
+      panIndex,
+      panOpacity,
+      layouts,
+      horizontal,
+    }),
+    [
+      activeKey,
+      activeIndex,
+      keyExtractor,
+      pan,
+      panIndex,
+      panOpacity,
+      layouts,
+      horizontal,
+    ]
   );
 
   return (
@@ -60,7 +80,7 @@ export function useDragListContext<T>() {
   const value = useContext(DragListContext);
   if (!value) {
     throw new Error(
-      "useDragListContext must be called within DragListProvider",
+      "useDragListContext must be called within DragListProvider"
     );
   }
   return value as DragListContextValue<T>;


### PR DESCRIPTION
There was a timing issue between when `pan.setValue(0)` was called relative to when the newly-reordered list is rendered. I investigated a bunch of ways to fix this, including mirroring the list, but in the end the best way is to hide the dragged object briefly when the list is re-rendered so it doesn't jump visually on the screen.