### PR TITLE
fix: Need to re-render when data changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -386,6 +386,7 @@ function DragListImpl<T>(
     // rendering. This only truly matters during a reorder-triggered rendering, where we keep our
     // own copy of `data`.
     dataRef.current = data;
+    setExtra({ activeKey: null, panIndex: -1 }); // Trigger a re-render whenever data changes
   }, [data]);
 
   const renderDragItem = useCallback(


### PR DESCRIPTION
When we move to a ref, we should re-render deliberately when data changes. Otherwise React may not re-render after the `useEffect`.