### PR TITLE
fix: Use more efficient way to keep refs up to date

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,19 +118,13 @@ function DragListImpl<T>(
     null
   );
 
-  // The following refs exist only to avoid unnecessary re-renders, so we keep them up to date
-  // immediately using `useMemo` as opposed to `useEffect`, which allows them technically to be
-  // wrong/off for one render (since effects run after a render is done).
-  const hoverRef = useRef(props.onHoverChanged);
   // #78 - keep onHoverChanged up to date in our ref
-  hoverRef.current = useMemo(
-    () => props.onHoverChanged,
-    [props.onHoverChanged]
-  );
+  const hoverRef = useRef(props.onHoverChanged);
+  hoverRef.current = props.onHoverChanged;
   const reorderRef = useRef(props.onReordered);
-  reorderRef.current = useMemo(() => props.onReordered, [props.onReordered]);
+  reorderRef.current = props.onReordered;
   const keyExtractorRef = useRef(keyExtractor);
-  keyExtractorRef.current = useMemo(() => keyExtractor, [keyExtractor]);
+  keyExtractorRef.current = keyExtractor;
 
   // #76 When we finalize a reordering (i.e. when our parent gets `onReordered`), we need to
   // insulate ourselves from the parent changing the data we render without us controlling the


### PR DESCRIPTION
A useMemo wasn't actually necessary to accomplish the aims we had. Simply assigning the latest props values into the references, on every render, is better than running the useMemo on every render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how callback references are updated to ensure the latest values are always used, resulting in more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->