### PR TITLE
fix: #107 Stop flashing when item is dropped

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,12 @@
 import React, {useMemo, useState} from 'react';
-import {FlatList, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {
+  Button,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import DragList, {DragListRenderItemInfo} from 'react-native-draglist';
 
 const SOUND_OF_SILENCE = ['hello', 'darkness', 'my', 'old', 'friend'];
@@ -79,7 +86,7 @@ export default function DraggableLyrics() {
         onReordered={onReordered}
         renderItem={renderItem}
       />
-      {/* <Text style={styles.header}>Auto-Scrolling List</Text>
+      <Text style={styles.header}>Auto-Scrolling List</Text>
       <DragList
         style={styles.scrolledList}
         ref={listRef} // Verify that using the ref works
@@ -101,7 +108,7 @@ export default function DraggableLyrics() {
         keyExtractor={keyExtractor}
         onReordered={onReorderedHorz}
         renderItem={renderItem}
-      /> */}
+      />
     </View>
   );
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,12 +1,5 @@
 import React, {useMemo, useState} from 'react';
-import {
-  Button,
-  FlatList,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import {FlatList, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
 import DragList, {DragListRenderItemInfo} from 'react-native-draglist';
 
 const SOUND_OF_SILENCE = ['hello', 'darkness', 'my', 'old', 'friend'];
@@ -86,7 +79,7 @@ export default function DraggableLyrics() {
         onReordered={onReordered}
         renderItem={renderItem}
       />
-      <Text style={styles.header}>Auto-Scrolling List</Text>
+      {/* <Text style={styles.header}>Auto-Scrolling List</Text>
       <DragList
         style={styles.scrolledList}
         ref={listRef} // Verify that using the ref works
@@ -108,7 +101,7 @@ export default function DraggableLyrics() {
         keyExtractor={keyExtractor}
         onReordered={onReorderedHorz}
         renderItem={renderItem}
-      />
+      /> */}
     </View>
   );
 }

--- a/src/DragListContext.tsx
+++ b/src/DragListContext.tsx
@@ -31,6 +31,7 @@ type ContextProps<T> = {
   layouts: LayoutCache;
   horizontal: boolean | null | undefined;
   children: React.ReactNode;
+  dataGen: number;
 };
 
 type DragListContextValue<T> = Omit<ContextProps<T>, "children">;
@@ -48,6 +49,7 @@ export function DragListProvider<T>({
   layouts,
   horizontal,
   children,
+  dataGen,
 }: ContextProps<T>) {
   const value = useMemo(
     () => ({
@@ -58,8 +60,18 @@ export function DragListProvider<T>({
       isReordering,
       layouts,
       horizontal,
+      dataGen,
     }),
-    [activeData, keyExtractor, pan, panIndex, isReordering, layouts, horizontal]
+    [
+      activeData,
+      keyExtractor,
+      pan,
+      panIndex,
+      isReordering,
+      layouts,
+      horizontal,
+      dataGen,
+    ]
   );
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -562,7 +562,7 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
   // #76 This is done as a memo instead of an effect because we want the anim change to start right
   // away, even on this very render (e.g. cases where we set it immediately to zero), whereas an
   // effect would render this without that change first, and then start changing anim.
-  const _animCharge = useMemo(() => {
+  const _animChange = useMemo(() => {
     if (isReordering) {
       // Do not change anim when reordering. Even though it seems safe to do, iOS v. Android
       // could/do recycle views and changing the anim will cause things to visually jump even if you

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -371,7 +371,7 @@ function DragListImpl<T>(
   console.log(`dataGenRef.current: ${dataGenRef.current}`);
 
   useLayoutEffect(() => {
-    // setPan(0);
+    setPan(0);
   }, [data]);
 
   const renderDragItem = useCallback(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -592,12 +592,12 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
         }
       }
     }
-    // return Animated.timing(anim, {
-    //   duration: activeData?.key ? SLIDE_MILLIS : 0,
-    //   easing: Easing.inOut(Easing.linear),
-    //   toValue: 0,
-    //   useNativeDriver: true,
-    // }).start();
+    return Animated.timing(anim, {
+      duration: activeData?.key ? SLIDE_MILLIS : 0,
+      easing: Easing.inOut(Easing.linear),
+      toValue: 0,
+      useNativeDriver: true,
+    }).start();
   }, [index, panIndex, activeData, isReordering]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
 ## Description
We've had a lot of rendering issues where a dropped item briefly flashes in its pre-drop location before settling in its final spot. This fixes all that by better synchronizing internal Animation.Value() settings with when the parent updates `data` in response to `onReordered`. We introduce the idea of a data "generation" number (`dataGen`) which gets revised every time the parent provides new data. We use `dataGen` to decide when to flush old animation values. And to deliberately prevent React Native from recycling native views in cases where we know `dataGen` has been revved.

 ## Testing
Ran on iOS and Android simulators, dragged around, dropped at list ends, tapped-and-didn't-move. All seems to work on both platforms.