### PR TITLE
feat: clamp drag bounds when scrolling is disabled

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -233,12 +233,15 @@ function DragListImpl<T>(
 
       const dragItemExtent = layouts[activeDataRef.current.key].extent;
 
+      const pointerOffsetWithinItem =
+        dragItemExtent / 2 - grantActiveCenterOffsetRef.current;
+
       if (props.scrollEnabled === false && flatWrapLayout.current.extent > 0) {
-        const halfExtent = dragItemExtent / 2;
-        const minWrapPos = halfExtent;
+        const minWrapPos = pointerOffsetWithinItem;
         const maxWrapPos = Math.max(
           minWrapPos,
-          flatWrapLayout.current.extent - halfExtent
+          flatWrapLayout.current.extent -
+            (dragItemExtent - pointerOffsetWithinItem)
         );
         const clampedWrapPos = Math.min(
           Math.max(wrapPos, minWrapPos),


### PR DESCRIPTION
## Summary
- clamp the drag position when `scrollEnabled` is false so the active item stays within the list viewport
- skip triggering auto-scroll when manual scrolling is disabled to avoid drifting beyond the container

Implements #111

## Testing
Hacked the example and verified behavior.