### PR TITLE
fix: grace period for parents to echo data before force-resetting a reorder

### DIFF
--- a/src/__tests__/DragList.test.tsx
+++ b/src/__tests__/DragList.test.tsx
@@ -527,6 +527,54 @@ describe("atomic transform resets (bug: drop flashes at old position)", () => {
     expect(harness.flatList().props.scrollEnabled).toBe(true);
   });
 
+  it("does not tear down a drag that superseded the released one during an async onReordered", async () => {
+    // While onReordered is still awaiting, presses reach rows (only responder
+    // capture is blocked), so a user can start a new drag. The release's
+    // finally-block teardown must recognize it no longer owns the drag state
+    // and leave the superseding drag alone — neither arming a grace timer
+    // against it nor resetting it.
+    let resolveReorder!: () => void;
+    const harness = renderDragList({
+      onReordered: () =>
+        new Promise<void>(resolve => {
+          resolveReorder = resolve;
+        }),
+    });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+
+    // onReordered is still pending; the user starts a new drag.
+    await act(async () => {
+      harness.infos["gamma"].onDragStart();
+    });
+    await act(async () => {
+      resolveReorder();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(harness.infos["gamma"].isActive).toBe(true);
+    // The new drag must also be capturable (no pending grace timer blocking).
+    expect(
+      harness.config.onStartShouldSetPanResponderCapture?.(
+        {} as any,
+        { x0: 0, y0: 250, dx: 0, dy: 0 } as any
+      )
+    ).toBe(true);
+  });
+
   it("does not let a stale grace timer kill a subsequent drag", async () => {
     const harness = renderDragList({ onReordered: () => {} });
     await startGrantedDrag(harness);

--- a/src/__tests__/DragList.test.tsx
+++ b/src/__tests__/DragList.test.tsx
@@ -376,7 +376,7 @@ describe("atomic transform resets (bug: drop flashes at old position)", () => {
     }
   });
 
-  it("tears down the drag even when the parent never echoes new data after onReordered", async () => {
+  it("tears down the drag via the grace fallback when the parent never echoes new data after onReordered", async () => {
     const onDragEnd = jest.fn();
     const harness = renderDragList({ onDragEnd, onReordered: () => {} });
     await startGrantedDrag(harness);
@@ -392,13 +392,80 @@ describe("atomic transform resets (bug: drop flashes at old position)", () => {
         { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
       );
     });
-    // Parent deliberately does NOT update data.
-
+    // Parent deliberately does NOT update data. onDragEnd is owed at release
+    // regardless, but the visual teardown waits for the grace period.
     expect(onDragEnd).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
     expect(
       Object.values(harness.infos).every(info => !info.isActive)
     ).toBe(true);
     expect(harness.flatList().props.scrollEnabled).toBe(true);
+  });
+
+  it("holds the drag state after onReordered resolves instead of resetting before the parent's data arrives", async () => {
+    // Parents backed by async/debounced stores hand back new data later than
+    // the microtask queue. Resetting the moment onReordered resolves would
+    // snap the item back and then jump it once data arrives; instead the
+    // reset waits (within a grace period) for the data change, which tears
+    // down atomically in the same commit as the move.
+    const harness = renderDragList({ onReordered: () => {} });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+
+    // No data change and no grace expiry yet: the drag visuals must be held.
+    expect(
+      Object.values(harness.infos).some(info => info.isActive)
+    ).toBe(true);
+
+    // The (late) data change still resets atomically.
+    harness.update(["beta", "alpha", "gamma"]);
+    expect(
+      Object.values(harness.infos).every(info => !info.isActive)
+    ).toBe(true);
+  });
+
+  it("does not let a stale grace timer kill a subsequent drag", async () => {
+    const harness = renderDragList({ onReordered: () => {} });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    // Parent echoes the reorder; the pending grace timer must be disarmed.
+    harness.update(["beta", "alpha", "gamma"]);
+
+    // Start a new drag, then let any stale timer fire.
+    await act(async () => {
+      harness.infos["gamma"].onDragStart();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(harness.infos["gamma"].isActive).toBe(true);
   });
 });
 

--- a/src/__tests__/DragList.test.tsx
+++ b/src/__tests__/DragList.test.tsx
@@ -439,6 +439,94 @@ describe("atomic transform resets (bug: drop flashes at old position)", () => {
     ).toBe(true);
   });
 
+  it("resets immediately after a moved drop when no onReordered is provided", async () => {
+    // Without an onReordered callback, no parent can possibly echo new data,
+    // so the grace window would just hold the list unscrollable for nothing.
+    const harness = renderDragList({});
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+
+    expect(
+      Object.values(harness.infos).every(info => !info.isActive)
+    ).toBe(true);
+    expect(harness.flatList().props.scrollEnabled).toBe(true);
+  });
+
+  it("does not capture the pan responder during the grace window", async () => {
+    // activeDataRef stays set while we wait for the parent's data, but a
+    // stray touch must not be captured as a pan of the old held item — that
+    // could fire a second onReordered with stale indices.
+    const harness = renderDragList({ onReordered: () => {} });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    // Parent hasn't echoed data yet: grace window is open.
+
+    expect(
+      harness.config.onStartShouldSetPanResponderCapture?.(
+        {} as any,
+        { x0: 0, y0: 250, dx: 0, dy: 0 } as any
+      )
+    ).toBe(false);
+  });
+
+  it("recovers when a drag started during the grace window is released without movement", async () => {
+    // Starting a new drag disarms the grace fallback. If that drag then ends
+    // before the responder is granted (press without movement), the teardown
+    // must not be blocked by grant state left over from the previous drag.
+    const harness = renderDragList({ onReordered: () => {} });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+
+    // Press a row during the grace window, then release without moving.
+    await act(async () => {
+      harness.infos["gamma"].onDragStart();
+    });
+    await act(async () => {
+      harness.infos["gamma"].onDragEnd();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(
+      Object.values(harness.infos).every(info => !info.isActive)
+    ).toBe(true);
+    expect(harness.flatList().props.scrollEnabled).toBe(true);
+  });
+
   it("does not let a stale grace timer kill a subsequent drag", async () => {
     const harness = renderDragList({ onReordered: () => {} });
     await startGrantedDrag(harness);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -434,7 +434,11 @@ function DragListImpl<T>(
 
   const onPanResponderRelease = useCallback(
     async (_: GestureResponderEvent, _gestate: PanResponderGestureState) => {
-      const activeIndex = activeDataRef.current?.index;
+      // The drag this release belongs to. While onReordered awaits, presses
+      // still reach rows (only responder capture is blocked), so a new drag
+      // can supersede this one; teardown below must then stand down.
+      const releasedData = activeDataRef.current;
+      const activeIndex = releasedData?.index;
       let reorderCallback: typeof reorderRef.current;
 
       clearAutoScrollTimer();
@@ -476,7 +480,11 @@ function DragListImpl<T>(
           // data-change render path resets atomically in the same commit as
           // the move (clearing this timer via reset). Only if nothing
           // arrives within the grace period does this fallback fire.
-          if (activeDataRef.current) {
+          // Only tear down if this release still owns the drag state. If a
+          // drag started mid-await, arming the grace timer (or resetting)
+          // here would freeze and then kill that new drag; its own lifecycle
+          // handles teardown instead.
+          if (activeDataRef.current && activeDataRef.current === releasedData) {
             if (!reorderCallback) {
               // No onReordered callback means no parent can possibly echo
               // new data — waiting would just hold the list unscrollable.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -268,7 +268,16 @@ function DragListImpl<T>(
   );
 
   const shouldCapturePan = useCallback(() => {
-    return !!activeDataRef.current && !isReorderingRef.current;
+    // While a reorder's grace timer is pending, activeDataRef is still set
+    // (the drag posture is held for the parent's data change), but a stray
+    // touch must not be captured as a pan of the old item — releasing it
+    // could fire a second onReordered with stale indices. A deliberate new
+    // drag still works: the row's onDragStart disarms the timer first.
+    return (
+      !!activeDataRef.current &&
+      !isReorderingRef.current &&
+      !graceResetTimerRef.current
+    );
   }, []);
 
   const onPanResponderGrant = useCallback(
@@ -426,6 +435,7 @@ function DragListImpl<T>(
   const onPanResponderRelease = useCallback(
     async (_: GestureResponderEvent, _gestate: PanResponderGestureState) => {
       const activeIndex = activeDataRef.current?.index;
+      let reorderCallback: typeof reorderRef.current;
 
       clearAutoScrollTimer();
       fireOwedDragEnd();
@@ -448,7 +458,8 @@ function DragListImpl<T>(
           // stale).
           isReorderingRef.current = true;
 
-          await reorderRef.current?.(activeIndex, panIndex.current);
+          reorderCallback = reorderRef.current;
+          await reorderCallback?.(activeIndex, panIndex.current);
         } finally {
           isReorderingRef.current = false;
           // #76 - Normally we don't reset here; the parent's data change
@@ -466,13 +477,19 @@ function DragListImpl<T>(
           // the move (clearing this timer via reset). Only if nothing
           // arrives within the grace period does this fallback fire.
           if (activeDataRef.current) {
-            clearGraceResetTimer();
-            graceResetTimerRef.current = setTimeout(() => {
-              graceResetTimerRef.current = null;
-              if (activeDataRef.current) {
-                reset();
-              }
-            }, REORDER_RESET_GRACE_MILLIS);
+            if (!reorderCallback) {
+              // No onReordered callback means no parent can possibly echo
+              // new data — waiting would just hold the list unscrollable.
+              reset();
+            } else {
+              clearGraceResetTimer();
+              graceResetTimerRef.current = setTimeout(() => {
+                graceResetTimerRef.current = null;
+                if (activeDataRef.current) {
+                  reset();
+                }
+              }, REORDER_RESET_GRACE_MILLIS);
+            }
           }
         }
       } else {
@@ -575,8 +592,12 @@ function DragListImpl<T>(
     if (dataRef.current.length > 1) {
       // If a reorder's grace timer is still pending (parent never echoed new
       // data), starting a fresh drag supersedes it — the timer must not fire
-      // later and tear down the new drag.
+      // later and tear down the new drag. The previous drag's grant flag must
+      // also be cleared: reset() normally does that, but the grace window
+      // defers reset, and a stale true here would block endDrag's teardown if
+      // this new drag ends before being granted (press without movement).
       clearGraceResetTimer();
+      panGrantedRef.current = false;
       // Zero pan synchronously before the activation render attaches it,
       // so the new active item can't inherit a stale offset from a
       // previous drag (setValue also pushes to the native side before the

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -189,6 +189,17 @@ function DragListImpl<T>(
   const autoScrollTimerRef = useRef<ReturnType<typeof setInterval> | null>(
     null
   );
+  // Fallback teardown for reorders whose parent never hands back new data
+  // (see the grace-timer comment in onPanResponderRelease).
+  const graceResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const clearGraceResetTimer = useCallback(() => {
+    if (graceResetTimerRef.current) {
+      clearTimeout(graceResetTimerRef.current);
+      graceResetTimerRef.current = null;
+    }
+  }, []);
 
   // #78 - keep onHoverChanged up to date in our ref
   const hoverRef = useRef(props.onHoverChanged);
@@ -446,17 +457,22 @@ function DragListImpl<T>(
           // parent never hands us new data (e.g. it mutated in place), we
           // must still tear the drag down or the list stays stuck.
           //
-          // This does not race the parent's commit. On React 18+, a setData
-          // called during onReordered is still pending when this microtask
-          // runs, so reset()'s setState batches with it into a single commit
-          // (new data + cleared drag state together). On React 17, setData
-          // flushed synchronously during onReordered, which already ran
-          // reset(false) via the data-change render, so activeDataRef is
-          // null here and we skip. Only parents that defer setData past the
-          // microtask queue (setTimeout etc.) see a reset against old data —
-          // a brief snap-back, which beats a permanently stuck drag.
+          // We don't reset the moment onReordered resolves, though: parents
+          // backed by async/debounced stores hand back new data later than
+          // the microtask queue, and an eager reset would snap the item back
+          // and then jump it once the data arrived. Instead we arm a grace
+          // timer. In the normal case the data change lands first and the
+          // data-change render path resets atomically in the same commit as
+          // the move (clearing this timer via reset). Only if nothing
+          // arrives within the grace period does this fallback fire.
           if (activeDataRef.current) {
-            reset();
+            clearGraceResetTimer();
+            graceResetTimerRef.current = setTimeout(() => {
+              graceResetTimerRef.current = null;
+              if (activeDataRef.current) {
+                reset();
+              }
+            }, REORDER_RESET_GRACE_MILLIS);
           }
         }
       } else {
@@ -503,6 +519,7 @@ function DragListImpl<T>(
    * When you don't want to trigger a re-render, pass false so we don't setExtra.
    */
   const reset = useCallback((shouldSetExtra = true) => {
+    clearGraceResetTimer();
     activeDataRef.current = null;
     panIndex.current = -1;
     hoverBus.index = -1;
@@ -539,6 +556,9 @@ function DragListImpl<T>(
   // function body_. That's right. Having it here changes timings or something in React Native so
   // our rendering is reset correctly, even if you do absolutely nothing in the function. As it
   // stands, we need to reset the pan, so it's all good.
+  // Disarm the grace fallback if we unmount while it's pending.
+  useEffect(() => clearGraceResetTimer, [clearGraceResetTimer]);
+
   useLayoutEffect(() => {
     setPan(0);
     // If a data change killed a live drag (reset(false) above), the host
@@ -553,6 +573,10 @@ function DragListImpl<T>(
   const startDrag = useCallback((index: number, key: string) => {
     // We don't allow dragging for lists less than 2 elements
     if (dataRef.current.length > 1) {
+      // If a reorder's grace timer is still pending (parent never echoed new
+      // data), starting a fresh drag supersedes it — the timer must not fire
+      // later and tear down the new drag.
+      clearGraceResetTimer();
       // Zero pan synchronously before the activation render attaches it,
       // so the new active item can't inherit a stale offset from a
       // previous drag (setValue also pushes to the native side before the
@@ -677,6 +701,11 @@ function DragListImpl<T>(
 
 const SLIDE_MILLIS = 200;
 const AUTO_SCROLL_MILLIS = 200;
+// How long, after onReordered resolves, we wait for the parent's data change
+// (the atomic teardown path) before force-resetting the drag. Long enough for
+// async/debounced stores to round-trip; short enough that a parent that never
+// echoes data doesn't leave the list stuck with scrolling disabled.
+const REORDER_RESET_GRACE_MILLIS = 1500;
 const ANIM_VALUE_ZERO = new Animated.Value(0);
 const ANIM_VALUE_ONE = new Animated.Value(1);
 const ANIM_VALUE_NINER = new Animated.Value(999);


### PR DESCRIPTION
## Problem

After \`onReordered\` resolves, DragList reset the drag immediately if the parent hadn't yet handed back new data. That's correct for parents that \`setState\` during \`onReordered\` (the reset batches into the same commit), but too eager for parents backed by **async or debounced stores**: their data change lands later than the microtask queue, so the item snapped back to its old position and then jumped to the new one when the data arrived.

## Fix

Instead of resetting the moment the promise settles, the release path arms a **~1.5s grace timer**:

- **Normal case** (including debounced stores): the parent's data change arrives first, and the existing data-change path resets **atomically in the same commit as the move** — exactly the #76 behavior, unchanged.
- **Fallback**: only if no data change arrives within the grace period does \`reset()\` fire, so a parent that never echoes data (e.g. mutates in place) still can't leave the list stuck with scrolling disabled.

The timer is disarmed by \`reset()\` (which covers the data-change path and every other teardown), by a new drag starting (a stale fallback can never tear down a subsequent drag — under test), and on unmount.

## Trade-offs

- \`onDragEnd\` timing is unchanged — it still fires at release, so the begin/end pairing invariant holds.
- During the grace window the list keeps its drag-time posture (scroll disabled, item held at its hover position). That window only stays open as long as the parent hasn't responded; for parents that echo data promptly it is effectively zero.

## Tests

New: holds drag state after \`onReordered\` resolves until data arrives (the async-store case); late data change still resets atomically; stale grace timer can't kill a subsequent drag. Updated: the never-echoes-data teardown test now advances past the grace period. 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)