### PR TITLE
fix: settle owed onDragEnd on unmount; keep idle stacking on Animated values

### DIFF
--- a/src/__tests__/DragList.test.tsx
+++ b/src/__tests__/DragList.test.tsx
@@ -301,6 +301,44 @@ describe("mid-drag data changes", () => {
     expect(onDragEnd).toHaveBeenCalledTimes(1);
   });
 
+  it("fires the owed onDragEnd when the list unmounts mid-drag", async () => {
+    // A parent may unmount the list while a drag is live (e.g. hiding it based
+    // on other state) before any release/terminate event or data change
+    // arrives. The onDragBegin/onDragEnd pairing guarantee must still hold, or
+    // hosts tracking isDragging via these callbacks get stuck.
+    const onDragBegin = jest.fn();
+    const onDragEnd = jest.fn();
+    const harness = renderDragList({ onDragBegin, onDragEnd });
+    await startGrantedDrag(harness);
+    expect(onDragBegin).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).not.toHaveBeenCalled();
+
+    act(() => {
+      harness.renderer.unmount();
+    });
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onDragEnd again on unmount after a drag already ended", async () => {
+    const onDragEnd = jest.fn();
+    const harness = renderDragList({ onDragEnd });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 0 } as any
+      );
+    });
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      harness.renderer.unmount();
+    });
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
   it("fires onDragEnd on release even when nothing was reordered", async () => {
     const onDragEnd = jest.fn();
     const harness = renderDragList({ onDragEnd });
@@ -602,6 +640,61 @@ describe("atomic transform resets (bug: drop flashes at old position)", () => {
     });
 
     expect(harness.infos["gamma"].isActive).toBe(true);
+  });
+});
+
+describe("idle stacking resets (bug: raw elevation/zIndex ignored on RN 0.76.3+)", () => {
+  // Returns the flattened {elevation, zIndex} of each cell's composite
+  // Animated.View, without resolving Animated nodes to numbers.
+  function cellStackingStyles(harness: Harness): Array<{ [k: string]: any }> {
+    const cells = harness.renderer.root.findAll(
+      node =>
+        typeof node.type === "function" &&
+        node.type.name === "CellRendererComponent"
+    );
+    return cells.map(cell => {
+      const animatedView = cell.findAll(
+        (node: any) =>
+          typeof node.type !== "string" &&
+          node.props &&
+          typeof node.props.onLayout === "function" &&
+          node.props.style
+      )[0];
+      const flat = [animatedView.props.style]
+        .flat(Infinity)
+        .filter(Boolean)
+        .reduce((acc: any, s: any) => ({ ...acc, ...s }), {});
+      return { elevation: flat.elevation, zIndex: flat.zIndex };
+    });
+  }
+
+  it("resets elevation and zIndex via Animated values in the commit that applies reordered data", async () => {
+    // On RN 0.76.3+, raw numbers for elevation/zIndex on an Animated.View
+    // don't take effect (see issue #53). After a dragged cell rendered with
+    // Animated ONE/999, returning to idle with raw zeros can leave stale
+    // native stacking, so the idle branch must keep these on Animated values.
+    const harness = renderDragList({ onReordered: () => {} });
+    await startGrantedDrag(harness);
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 120 } as any
+      );
+    });
+    harness.update(["beta", "alpha", "gamma"]);
+
+    for (const style of cellStackingStyles(harness)) {
+      expect(typeof style.elevation).not.toBe("number");
+      expect(style.elevation?.__getValue?.()).toBe(0);
+      expect(typeof style.zIndex).not.toBe("number");
+      expect(style.zIndex?.__getValue?.()).toBe(0);
+    }
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -581,8 +581,18 @@ function DragListImpl<T>(
   // function body_. That's right. Having it here changes timings or something in React Native so
   // our rendering is reset correctly, even if you do absolutely nothing in the function. As it
   // stands, we need to reset the pan, so it's all good.
-  // Disarm the grace fallback if we unmount while it's pending.
-  useEffect(() => clearGraceResetTimer, [clearGraceResetTimer]);
+  // Unmount cleanup: disarm the grace fallback if it's pending, and settle
+  // any owed onDragEnd. A parent can unmount the list mid-drag (e.g. hiding
+  // it based on other state) before any release/terminate event or data
+  // change runs the other teardown paths, and onDragBegin/onDragEnd must
+  // still pair up.
+  useEffect(
+    () => () => {
+      clearGraceResetTimer();
+      fireOwedDragEnd();
+    },
+    [clearGraceResetTimer, fireOwedDragEnd]
+  );
 
   useLayoutEffect(() => {
     setPan(0);
@@ -784,8 +794,13 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
             ],
           }
         : {
-            elevation: 0,
-            zIndex: 0,
+            // elevation/zIndex stay Animated-backed even when idle: per the
+            // RN 0.76.3+ quirk above, raw numbers here don't take effect, so
+            // a just-dropped cell could keep its dragged stacking. These are
+            // module-level constants that never animate, so the transform's
+            // static-commit guarantee is unaffected.
+            elevation: ANIM_VALUE_ZERO,
+            zIndex: ANIM_VALUE_ZERO,
             transform: [horizontal ? { translateX: 0 } : { translateY: 0 }],
           },
     ];


### PR DESCRIPTION
Addresses the two remaining review findings from #116 (Codex P2s).

## Unmount mid-drag never fired the owed `onDragEnd`

If a parent unmounted the list while a drag was live (e.g. conditionally hiding it) before any release/terminate event or data change arrived, none of the teardown paths ran, so `onDragBegin` was never paired with `onDragEnd`. Hosts tracking `isDragging` via the callbacks stayed stuck — contradicting the pairing guarantee the README advertises. The unmount cleanup (which already disarmed the grace timer) now also settles the owed `onDragEnd`.

## Idle cells reset elevation/zIndex with raw numbers

Starting RN 0.76.3, raw numbers for `elevation`/`zIndex` on an `Animated.View` don't take effect (#53). The idle branch reset them with raw `0`s, so a just-dropped cell could keep its dragged stacking. Idle cells now use the never-animated module constant `ANIM_VALUE_ZERO`. The transform itself remains a raw `0`, so the atomic static-commit drop behavior from #116 is unchanged (covered by the existing transform tests).

## Tests

Both fixes were written test-first; the new tests fail on `main`:
- `fires the owed onDragEnd when the list unmounts mid-drag`
- `does not fire onDragEnd again on unmount after a drag already ended`
- `resets elevation and zIndex via Animated values in the commit that applies reordered data`

All 30 tests pass; `npm run build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)