### PR TITLE
fix: support RTL in horizontal lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - `npm run build` — builds via microbundle-crl (`--no-compress --format modern,cjs`) into `dist/`
 - `npm run release` — releases via release-it (with conventional changelog and GitHub release)
 - `npm run prepare` — runs build automatically on `npm install`
-- `npm test` — runs the Jest regression suite in `src/__tests__/` (responder termination, mid-drag data changes, key stability). No linting configured.
+- `npm test` — runs the Jest regression suite in `src/__tests__/` (responder termination, mid-drag data changes, key stability, mirrored/RTL layouts). No linting configured.
 
 ## Development Workflow
 
@@ -24,6 +24,10 @@ All validation is manual — test on **both iOS and Android**. Key test cases:
 - Drag-and-release back to original position
 - "Scroll to Top" button (verifies forwardRef)
 - Horizontal list dragging
+- The same horizontal cases under RTL, via the example app's direction toggle. On iOS the toggle's
+  reload isn't enough — relaunch natively (`xcrun simctl terminate`/`launch`) for `forceRTL` to take
+  effect. Watch the printed data order under the horizontal list: the visual order mirrors, so it's
+  the only way to tell a correct drop from one that landed at the mirrored index.
 
 ## Architecture
 
@@ -40,6 +44,7 @@ Two source files:
 - **Drag teardown invariant** — `props.onDragBegin`/`props.onDragEnd` must always pair up. `dragEndOwedRef` tracks the debt; every teardown path (release, `onPanResponderTerminate`, mid-drag data change) settles it via `fireOwedDragEnd`. Responder termination commits the reorder at the current hover index (deliberate choice — see README caveat on gesture recognizers).
 - **Ref-based state for non-render paths** — `activeDataRef`, `panIndex`, `scrollPos`, `panGrantedRef` etc. are refs to avoid unnecessary re-renders during drag. `setExtra` is used sparingly to trigger re-renders only when needed.
 - **Reorder serialization** — `isReorderingRef` prevents new pan captures during an async `onReordered` callback to avoid stale-index bugs.
+- **Flow order vs. coordinate order** — Anything relating positions to indices must walk in *flow* order (increasing with data index), which equals coordinate order only when the layout isn't mirrored. `isLayoutMirrored(horizontal)` is true for horizontal lists under `I18nManager.isRTL`, where Yoga mirrors the row so `layouts[key].pos` descends as the index rises. The hover scan compares negated coordinates via `flowTrailingEdge()`, and cell slide targets flip sign, since transforms aren't mirrored for us the way layout is. Separately, `scrollToOffset` takes a flow-relative offset under RTL (counted from the start of the data) while `onScroll`'s `contentOffset` stays cartesian, so `scrollPos`/`flowScrollPos` track both spaces; feeding the cartesian value to `scrollToOffset` makes VirtualizedList mirror an already-mirrored number and flings the list most of its length. `inverted` is a *different* mirror — render-stage `scaleX`/`scaleY` that Yoga never sees, so it flips the pointer-to-content mapping instead of the index ordering — and is unsupported; it needs its own predicate, not this one.
 
 ### Platform Workarounds
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ such things, but I suspect most attempts will be fraught with issues because the
 a multi-column list isn't immediately obvious, especially when the underlying `FlatList`
 implementation can't be controlled from the outside.
 
+## Does this work in right-to-left (RTL) layouts?
+Horizontal lists do. Vertical lists were never affected, since RTL only mirrors the horizontal axis.
+
+The reason horizontal lists needed work is that RTL mirrors a list in two places at once. Yoga
+mirrors the row during layout, so an item's measured position *descends* as its index rises, and
+`scrollToOffset` switches to counting its offset from the start of the data (the right edge) while
+`onScroll` keeps reporting a plain left-origin `contentOffset`. `DragList` accounts for both, so
+hit-testing, the slide animations, and auto-scroll all follow the data rather than the screen axis.
+
+`inverted` is a separate matter and is **not** supported. It mirrors at the render stage — a
+`scaleX`/`scaleY` transform that Yoga never sees — rather than at the layout stage, so it leaves
+positions ascending and instead flips the mapping from touch coordinates into content coordinates.
+Dragging in an `inverted` list will compute the wrong drop index. PRs welcome.
+
 ## Can I wrap my rows in other gesture recognizers (Swipeable, etc.)?
 Yes, but understand what happens when the two gesture systems fight. `DragList` uses React Native's
 `PanResponder` (the JS responder system). Native gesture recognizers — such as

--- a/README.md
+++ b/README.md
@@ -134,16 +134,9 @@ implementation can't be controlled from the outside.
 ## Does this work in right-to-left (RTL) layouts?
 Horizontal lists do. Vertical lists were never affected, since RTL only mirrors the horizontal axis.
 
-The reason horizontal lists needed work is that RTL mirrors a list in two places at once. Yoga
-mirrors the row during layout, so an item's measured position *descends* as its index rises, and
-`scrollToOffset` switches to counting its offset from the start of the data (the right edge) while
-`onScroll` keeps reporting a plain left-origin `contentOffset`. `DragList` accounts for both, so
-hit-testing, the slide animations, and auto-scroll all follow the data rather than the screen axis.
-
-`inverted` is a separate matter and is **not** supported. It mirrors at the render stage — a
-`scaleX`/`scaleY` transform that Yoga never sees — rather than at the layout stage, so it leaves
-positions ascending and instead flips the mapping from touch coordinates into content coordinates.
-Dragging in an `inverted` list will compute the wrong drop index. PRs welcome.
+`inverted` is a separate matter and is **not** supported. It mirrors a list by a different mechanism
+than RTL does, which this package doesn't account for, so dragging in an `inverted` list will
+compute the wrong drop index. PRs welcome.
 
 ## Can I wrap my rows in other gesture recognizers (Swipeable, etc.)?
 Yes, but understand what happens when the two gesture systems fight. `DragList` uses React Native's

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,7 +1,11 @@
 import React, {useMemo, useState} from 'react';
 import {
+  Alert,
   Button,
+  DevSettings,
   FlatList,
+  I18nManager,
+  SafeAreaView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -10,6 +14,20 @@ import {
 import DragList, {DragListRenderItemInfo} from 'react-native-draglist';
 
 const SOUND_OF_SILENCE = ['hello', 'darkness', 'my', 'old', 'friend'];
+// Long enough to overflow the screen, so horizontal auto-scroll is exercised.
+const HORZ_ITEMS = Array.from({length: 20}, (_, i) => `h${i}`);
+
+function toggleRTL() {
+  const next = !I18nManager.isRTL;
+
+  I18nManager.allowRTL(next);
+  I18nManager.forceRTL(next);
+  Alert.alert(
+    `Switching to ${next ? 'RTL' : 'LTR'}`,
+    'Reloading. If the direction does not change, fully quit and relaunch the app.',
+    [{text: 'OK', onPress: () => DevSettings.reload()}],
+  );
+}
 
 export default function DraggableLyrics() {
   const [data, setData] = useState(SOUND_OF_SILENCE);
@@ -18,7 +36,7 @@ export default function DraggableLyrics() {
       .map(num => SOUND_OF_SILENCE.map(word => `${word}${num}`))
       .flat(),
   );
-  const [horzData, setHorzData] = useState(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+  const [horzData, setHorzData] = useState(HORZ_ITEMS);
   const listRef = React.useRef<FlatList<string> | null>(null);
   const header = useMemo(() => {
     return (
@@ -53,6 +71,20 @@ export default function DraggableLyrics() {
     );
   }
 
+  function renderHorzItem(info: DragListRenderItemInfo<string>) {
+    const {item, onDragStart, onDragEnd, isActive} = info;
+
+    return (
+      <TouchableOpacity
+        key={item}
+        style={[styles.item, styles.horzItem, isActive && styles.active]}
+        onPressIn={onDragStart}
+        onPressOut={onDragEnd}>
+        <Text style={styles.text}>{item}</Text>
+      </TouchableOpacity>
+    );
+  }
+
   async function onReordered(fromIndex: number, toIndex: number) {
     const copy = [...data]; // Don't modify react data in-place
     const removed = copy.splice(fromIndex, 1);
@@ -78,45 +110,64 @@ export default function DraggableLyrics() {
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.header}>Basic List</Text>
-      <DragList
-        data={data}
-        keyExtractor={keyExtractor}
-        onReordered={onReordered}
-        renderItem={renderItem}
-      />
-      <Text style={styles.header}>Auto-Scrolling List</Text>
-      <DragList
-        style={styles.scrolledList}
-        ref={listRef} // Verify that using the ref works
-        data={scrollData}
-        keyExtractor={keyExtractor}
-        onReordered={onScrollReordered}
-        ListHeaderComponent={header}
-        ListFooterComponent={footer}
-        renderItem={renderItem}
-      />
-      <Button
-        onPress={() => listRef.current?.scrollToIndex({index: 0})}
-        title="Scroll to Top"
-      />
-      <Text style={styles.header}>Horizontal List</Text>
-      <DragList
-        data={horzData}
-        horizontal
-        keyExtractor={keyExtractor}
-        onReordered={onReorderedHorz}
-        renderItem={renderItem}
-      />
-    </View>
+    // SafeAreaView overwrites its own padding with the window insets, so the
+    // layout padding has to live on a child.
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.dirRow}>
+          <Text style={styles.dirLabel}>
+            Direction: {I18nManager.isRTL ? 'RTL' : 'LTR'}
+          </Text>
+          <Button
+            onPress={toggleRTL}
+            title={`Switch to ${I18nManager.isRTL ? 'LTR' : 'RTL'}`}
+          />
+        </View>
+        <Text style={styles.header}>Basic List</Text>
+        <DragList
+          data={data}
+          keyExtractor={keyExtractor}
+          onReordered={onReordered}
+          renderItem={renderItem}
+        />
+        <Text style={styles.header}>Auto-Scrolling List</Text>
+        <DragList
+          style={styles.scrolledList}
+          ref={listRef} // Verify that using the ref works
+          data={scrollData}
+          keyExtractor={keyExtractor}
+          onReordered={onScrollReordered}
+          ListHeaderComponent={header}
+          ListFooterComponent={footer}
+          renderItem={renderItem}
+        />
+        <Button
+          onPress={() => listRef.current?.scrollToIndex({index: 0})}
+          title="Scroll to Top"
+        />
+        <Text style={styles.header}>Horizontal List</Text>
+        <DragList
+          data={horzData}
+          horizontal
+          keyExtractor={keyExtractor}
+          onReordered={onReorderedHorz}
+          renderItem={renderHorzItem}
+        />
+        {/* The visual order mirrors under RTL, so print the logical order to
+            tell a correct drop apart from one that landed at the wrong index. */}
+        <Text style={styles.order}>{horzData.join(' ')}</Text>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
   container: {
     marginTop: 16,
-    padding: 40,
+    padding: 20,
     flex: 1,
   },
   header: {
@@ -139,5 +190,22 @@ const styles = StyleSheet.create({
   },
   scrolledList: {
     height: 300,
+  },
+  dirRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  dirLabel: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  horzItem: {
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+  },
+  order: {
+    marginTop: 8,
+    fontSize: 12,
   },
 });

--- a/src/__tests__/DragList.test.tsx
+++ b/src/__tests__/DragList.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { FlatList, PanResponder, Text } from "react-native";
+import { FlatList, I18nManager, PanResponder, Text } from "react-native";
 import TestRenderer, { act, ReactTestRenderer } from "react-test-renderer";
 import DragList, { DragListRenderItemInfo } from "../index";
 
 const DATA = ["alpha", "beta", "gamma"];
 const ITEM_EXTENT = 100;
 const LIST_EXTENT = 600;
+// The cross-axis size of the list, i.e. the one the drag math ignores.
+const LIST_BREADTH = 300;
 
 type Config = Parameters<typeof PanResponder.create>[0];
 
@@ -19,16 +21,26 @@ interface Harness {
   update: (data: string[]) => void;
   layoutCells: () => void;
   layoutWrapper: () => void;
+  scroll: (cartesianOffset: number, contentLength: number) => void;
   flatList: () => ReturnType<ReactTestRenderer["root"]["findByType"]>;
 }
 
 function renderDragList(props: {
   data?: string[];
+  horizontal?: boolean;
   onDragBegin?: () => void;
   onDragEnd?: () => void;
   onHoverChanged?: (hoverIndex: number) => void;
   onReordered?: (from: number, to: number) => Promise<void> | void;
 }): Harness {
+  const horizontal = !!props.horizontal;
+  // Under RTL, Yoga mirrors a horizontal row, so index 0 lands at the far end
+  // of the axis and positions descend from there.
+  const mirrored = horizontal && I18nManager.isRTL;
+  // The rect the wrapper's measure() and onLayout report.
+  const wrapRect = horizontal
+    ? { width: LIST_EXTENT, height: LIST_BREADTH }
+    : { width: LIST_BREADTH, height: LIST_EXTENT };
   const realCreate = PanResponder.create.bind(PanResponder);
   let config: Config | undefined;
   jest
@@ -50,6 +62,7 @@ function renderDragList(props: {
     return (
       <DragList
         data={data}
+        horizontal={horizontal}
         keyExtractor={(item: string) => item}
         renderItem={renderItem}
         onDragBegin={props.onDragBegin}
@@ -73,7 +86,7 @@ function renderDragList(props: {
             pageX: number,
             pageY: number
           ) => void
-        ) => cb(0, 0, 300, LIST_EXTENT, 0, 0),
+        ) => cb(0, 0, wrapRect.width, wrapRect.height, 0, 0),
       }),
     });
   });
@@ -95,10 +108,22 @@ function renderDragList(props: {
             pageX: number,
             pageY: number
           ) => void
-        ) => cb(0, 0, 300, LIST_EXTENT, 0, 0);
+        ) => cb(0, 0, wrapRect.width, wrapRect.height, 0, 0);
       });
   }
   patchMeasure();
+
+  // VirtualizedList's metrics aggregator refuses to resolve cell offsets
+  // until it knows the content size, because under RTL it mirrors them
+  // against the content length. Real lists always report this first.
+  function layoutContent() {
+    const scrollView = renderer.root.findAll(
+      node => typeof node.props?.onContentSizeChange === "function"
+    )[0];
+    act(() => {
+      scrollView.props.onContentSizeChange(wrapRect.width, wrapRect.height);
+    });
+  }
 
   const harness: Harness = {
     renderer,
@@ -124,13 +149,14 @@ function renderDragList(props: {
       act(() => {
         wrapper.props.onLayout({
           nativeEvent: {
-            layout: { x: 0, y: 0, width: 300, height: LIST_EXTENT },
+            layout: { x: 0, y: 0, ...wrapRect },
           },
         });
       });
     },
     // Fires onLayout on each cell so the internal layout cache is populated.
     layoutCells: () => {
+      layoutContent();
       const cells = renderer.root.findAll(
         node =>
           typeof node.type === "function" &&
@@ -143,17 +169,34 @@ function renderDragList(props: {
             typeof node.type === "string" &&
             typeof node.props.onLayout === "function"
         )[0];
+        const pos = mirrored
+          ? LIST_EXTENT - (index + 1) * ITEM_EXTENT
+          : index * ITEM_EXTENT;
         act(() => {
           view.props.onLayout({
             nativeEvent: {
-              layout: {
-                x: 0,
-                y: index * ITEM_EXTENT,
-                width: 300,
-                height: ITEM_EXTENT,
-              },
+              layout: horizontal
+                ? { x: pos, y: 0, width: ITEM_EXTENT, height: LIST_BREADTH }
+                : { x: 0, y: pos, width: LIST_BREADTH, height: ITEM_EXTENT },
             },
           });
+        });
+      });
+    },
+    // Reports a scroll at `cartesianOffset` (what contentOffset carries: an
+    // offset from the origin of the axis, regardless of layout direction).
+    scroll: (cartesianOffset: number, contentLength: number) => {
+      act(() => {
+        harness.flatList().props.onScroll({
+          nativeEvent: {
+            contentOffset: horizontal
+              ? { x: cartesianOffset, y: 0 }
+              : { x: 0, y: cartesianOffset },
+            contentSize: horizontal
+              ? { width: contentLength, height: LIST_BREADTH }
+              : { width: LIST_BREADTH, height: contentLength },
+            layoutMeasurement: wrapRect,
+          },
         });
       });
     },
@@ -163,7 +206,12 @@ function renderDragList(props: {
 }
 
 // Starts a drag on DATA[0] and grants the pan responder, centered on item 0.
-async function startGrantedDrag(harness: Harness) {
+// The default touch point suits a vertical list; horizontal ones pass their
+// own, since item 0 doesn't sit at the origin under a mirrored layout.
+async function startGrantedDrag(
+  harness: Harness,
+  origin: { x0: number; y0: number } = { x0: 0, y0: ITEM_EXTENT / 2 }
+) {
   harness.layoutWrapper();
   harness.layoutCells();
   await act(async () => {
@@ -172,10 +220,12 @@ async function startGrantedDrag(harness: Harness) {
   await act(async () => {
     harness.config.onPanResponderGrant?.(
       {} as any,
-      { x0: 0, y0: ITEM_EXTENT / 2, dx: 0, dy: 0 } as any
+      { ...origin, dx: 0, dy: 0 } as any
     );
   });
 }
+
+const ORIGINAL_RTL = I18nManager.isRTL;
 
 beforeEach(() => {
   // Fake timers keep the slide/pan Animated timers from firing after teardown.
@@ -183,6 +233,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  (I18nManager as { isRTL: boolean }).isRTL = ORIGINAL_RTL;
   renderers.forEach(renderer => {
     act(() => renderer.unmount());
   });
@@ -804,6 +855,197 @@ describe("hover changes don't re-render rows (perf)", () => {
     const resolved =
       typeof value === "number" ? value : value?.__getValue?.();
     expect(resolved).toBe(0);
+  });
+});
+
+describe("mirrored layouts (bug: RTL horizontal drags are frozen)", () => {
+  // Under RTL, Yoga mirrors the row so item 0 sits at the far right and
+  // cached positions descend with index. Walking the axis in coordinate
+  // order then pinned the hover index at 0 for the whole drag: the gap never
+  // followed your finger, neighbors slid away from the vacated slot instead
+  // of into it, and every drop reordered to index 0.
+  function cellTransform(harness: Harness, item: string): any {
+    const cells = harness.renderer.root.findAll(
+      node =>
+        typeof node.type === "function" &&
+        node.type.name === "CellRendererComponent"
+    );
+    const cell = cells.find(c => c.props.item === item)!;
+    // Horizontal lists hand CellRendererComponent its own `style` prop, so
+    // the cell node itself matches this predicate and has to be excluded to
+    // reach the Animated.View underneath.
+    const animatedView = cell.findAll(
+      (node: any) =>
+        node !== cell &&
+        typeof node.type !== "string" &&
+        node.props &&
+        typeof node.props.onLayout === "function" &&
+        node.props.style
+    )[0];
+    const flat = [animatedView.props.style]
+      .flat(Infinity)
+      .filter(Boolean)
+      .reduce((acc: any, s: any) => ({ ...acc, ...s }), {});
+    return flat.transform?.[0] ?? {};
+  }
+
+  // Item 0's center: at the origin end of the axis for LTR, at the far end
+  // for RTL.
+  const LTR_ITEM0_CENTER = ITEM_EXTENT / 2;
+  const RTL_ITEM0_CENTER = LIST_EXTENT - ITEM_EXTENT / 2;
+
+  it("tracks the hover index across a mirrored horizontal drag", async () => {
+    (I18nManager as { isRTL: boolean }).isRTL = true;
+    const onHoverChanged = jest.fn();
+    const harness = renderDragList({ horizontal: true, onHoverChanged });
+    await startGrantedDrag(harness, { x0: RTL_ITEM0_CENTER, y0: 0 });
+
+    // Under RTL, dragging leftward moves toward later indices.
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: RTL_ITEM0_CENTER, y0: 0, dx: -120, dy: 0 } as any
+      );
+    });
+
+    expect(onHoverChanged).toHaveBeenCalledWith(1);
+  });
+
+  it("reorders to the dropped position rather than to index 0 under RTL", async () => {
+    (I18nManager as { isRTL: boolean }).isRTL = true;
+    const onReordered = jest.fn();
+    const harness = renderDragList({ horizontal: true, onReordered });
+    await startGrantedDrag(harness, { x0: RTL_ITEM0_CENTER, y0: 0 });
+
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: RTL_ITEM0_CENTER, y0: 0, dx: -120, dy: 0 } as any
+      );
+    });
+    await act(async () => {
+      harness.config.onPanResponderRelease?.(
+        {} as any,
+        { x0: RTL_ITEM0_CENTER, y0: 0, dx: -120, dy: 0 } as any
+      );
+    });
+
+    expect(onReordered).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("slides a displaced neighbor into the vacated slot under RTL", async () => {
+    (I18nManager as { isRTL: boolean }).isRTL = true;
+    const harness = renderDragList({ horizontal: true });
+    await startGrantedDrag(harness, { x0: RTL_ITEM0_CENTER, y0: 0 });
+
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: RTL_ITEM0_CENTER, y0: 0, dx: -120, dy: 0 } as any
+      );
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    // alpha vacated the rightmost slot, so beta must slide right (toward
+    // higher coordinates) to fill it. Sliding left would open the
+    // double-width gap this bug was reported for.
+    const value = cellTransform(harness, "beta").translateX;
+    expect(value?.__getValue?.()).toBe(ITEM_EXTENT);
+  });
+
+  // A content length that overflows the viewport, so auto-scroll has
+  // somewhere to go.
+  const CONTENT_LENGTH = 2 * LIST_EXTENT;
+
+  function spyOnScrollToOffset(harness: Harness) {
+    const list = harness.flatList().instance as unknown as {
+      scrollToOffset: (params: { animated?: boolean; offset: number }) => void;
+    };
+    return jest
+      .spyOn(list, "scrollToOffset")
+      .mockImplementation(() => undefined);
+  }
+
+  it("auto-scrolls a mirrored list by an offset measured from the start of the data", async () => {
+    (I18nManager as { isRTL: boolean }).isRTL = true;
+    const harness = renderDragList({ horizontal: true });
+    await startGrantedDrag(harness, { x0: RTL_ITEM0_CENTER, y0: 0 });
+    // Showing the very start of the data: under RTL that sits at the far end
+    // of the axis, so contentOffset reads LIST_EXTENT while the offset
+    // scrollToOffset wants is 0.
+    harness.scroll(LIST_EXTENT, CONTENT_LENGTH);
+    const scrollToOffset = spyOnScrollToOffset(harness);
+
+    // Drag off the origin end of the axis, which under RTL means asking for
+    // later items.
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: RTL_ITEM0_CENTER, y0: 0, dx: -RTL_ITEM0_CENTER, dy: 0 } as any
+      );
+    });
+
+    // One item further into the data. Passing the cartesian position here
+    // instead makes VirtualizedList mirror an already-mirrored number and
+    // fling the list most of its length.
+    expect(scrollToOffset).toHaveBeenCalledWith({
+      animated: true,
+      offset: ITEM_EXTENT,
+    });
+  });
+
+  it("auto-scrolls a non-mirrored list by its cartesian offset", async () => {
+    const harness = renderDragList({ horizontal: true });
+    await startGrantedDrag(harness, { x0: LTR_ITEM0_CENTER, y0: 0 });
+    harness.scroll(LIST_EXTENT / 2, CONTENT_LENGTH);
+    const scrollToOffset = spyOnScrollToOffset(harness);
+
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: LTR_ITEM0_CENTER, y0: 0, dx: LIST_EXTENT, dy: 0 } as any
+      );
+    });
+
+    expect(scrollToOffset).toHaveBeenCalledWith({
+      animated: true,
+      offset: LIST_EXTENT / 2 + ITEM_EXTENT,
+    });
+  });
+
+  it("still tracks the hover index in a non-mirrored horizontal drag", async () => {
+    const onHoverChanged = jest.fn();
+    const harness = renderDragList({ horizontal: true, onHoverChanged });
+    await startGrantedDrag(harness, { x0: LTR_ITEM0_CENTER, y0: 0 });
+
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: LTR_ITEM0_CENTER, y0: 0, dx: 120, dy: 0 } as any
+      );
+    });
+
+    expect(onHoverChanged).toHaveBeenCalledWith(1);
+  });
+
+  it("still slides a displaced neighbor backwards in a non-mirrored horizontal drag", async () => {
+    const harness = renderDragList({ horizontal: true });
+    await startGrantedDrag(harness, { x0: LTR_ITEM0_CENTER, y0: 0 });
+
+    await act(async () => {
+      harness.config.onPanResponderMove?.(
+        {} as any,
+        { x0: LTR_ITEM0_CENTER, y0: 0, dx: 120, dy: 0 } as any
+      );
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    const value = cellTransform(harness, "beta").translateX;
+    expect(value?.__getValue?.()).toBe(-ITEM_EXTENT);
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import {
   FlatList,
   FlatListProps,
   GestureResponderEvent,
+  I18nManager,
   LayoutChangeEvent,
   ListRenderItemInfo,
   NativeScrollEvent,
@@ -154,6 +155,31 @@ const DragListItem = React.memo(
     prev.numItems === next.numItems
 ) as unknown as typeof DragListItemImpl;
 
+// Whether the list's layout runs opposite to its coordinate axis, i.e.
+// whether an item's cached `pos` DESCENDS as its index rises. Horizontal
+// lists do this under RTL: Yoga mirrors the row, so index 0 gets the largest
+// x, while touch coordinates and `contentOffset` stay plain left-origin.
+// Anything that relates positions to indices must therefore walk the axis in
+// "flow" order (increasing with index) rather than in coordinate order.
+//
+// This is deliberately only about the *layout* stage. The `inverted` prop
+// mirrors at the render stage instead — VirtualizedList applies a scaleX/
+// scaleY of -1 that Yoga never sees — which leaves `pos` ascending and
+// instead flips the mapping from touch coordinates into content
+// coordinates. That's an independent flag; supporting it means a second
+// predicate here plus its own handling, and it is currently unsupported.
+function isLayoutMirrored(horizontal: boolean | null | undefined) {
+  return !!horizontal && I18nManager.isRTL;
+}
+
+// An item's far edge in flow order: the edge you must drag past for the item
+// to count as sitting before you in the data. Mirrored layouts run backwards
+// through coordinate space, so their flow edge is the near one, negated to
+// keep flow positions ascending with index.
+function flowTrailingEdge(layout: PosExtent, mirrored: boolean) {
+  return mirrored ? -layout.pos : layout.pos + layout.extent;
+}
+
 function DragListImpl<T>(
   props: Props<T>,
   ref?: React.ForwardedRef<FlatList<T> | null>
@@ -247,7 +273,14 @@ function DragListImpl<T>(
     extent: 1,
   });
   const flatWrapRefPosUpdatedRef = useRef(false);
+  // The cartesian scroll offset, i.e. what `contentOffset` reports and what
+  // cached layouts are expressed in.
   const scrollPos = useRef(0);
+  // The same position counted from the start of the data instead of from the
+  // origin of the axis. The two only differ under a mirrored layout, where
+  // the data starts at the far end — but that's the space scrollToOffset
+  // works in, so auto-scroll targets have to be built here.
+  const flowScrollPos = useRef(0);
 
   // pan is the drag dy.
   //
@@ -334,6 +367,7 @@ function DragListImpl<T>(
         return;
       }
 
+      const mirrored = isLayoutMirrored(props.horizontal);
       const posOrigin = props.horizontal ? gestate.x0 : gestate.y0;
       let pos = props.horizontal ? gestate.dx : gestate.dy;
       let wrapPos = posOrigin + pos - flatWrapLayout.current.pos;
@@ -371,7 +405,14 @@ function DragListImpl<T>(
         // heights, starting from the first element. Note that we can't do
         // this math if any element up to your drag point hasn't been measured
         // yet. I don't think that should ever happen, but take note.
+        //
+        // The walk runs in flow order, which is coordinate order only when
+        // the layout isn't mirrored. Negating both sides under a mirrored
+        // layout keeps the comparison (and hence the loop) pointing the same
+        // way as the data.
         const clientPos = wrapPos + scrollPos.current;
+        const dragCenter = clientPos + grantActiveCenterOffsetRef.current;
+        const flowDragCenter = mirrored ? -dragCenter : dragCenter;
         let curIndex = 0;
         let key;
         while (
@@ -379,8 +420,7 @@ function DragListImpl<T>(
           layouts.hasOwnProperty(
             (key = keyExtractorRef.current(dataRef.current[curIndex], curIndex))
           ) &&
-          layouts[key].pos + layouts[key].extent <
-            clientPos + grantActiveCenterOffsetRef.current
+          flowTrailingEdge(layouts[key], mirrored) < flowDragCenter
         ) {
           curIndex++;
         }
@@ -414,9 +454,19 @@ function DragListImpl<T>(
 
       if (offset !== 0) {
         function scrollOnce(distance: number) {
+          // `distance` is a cartesian nudge — which way the content should
+          // slide under the viewport. scrollToOffset, though, takes an offset
+          // measured from the start of the data, so under a mirrored layout
+          // both the origin and the sign of the nudge have to be converted.
+          // Feeding it the cartesian position instead makes it convert a
+          // second time, which throws the list most of its length away.
+          const target = mirrored
+            ? flowScrollPos.current - distance
+            : scrollPos.current + distance;
+
           flatRef.current?.scrollToOffset({
             animated: true,
-            offset: Math.max(0, scrollPos.current + distance),
+            offset: Math.max(0, target),
           });
           updateRendering();
         }
@@ -670,9 +720,13 @@ function DragListImpl<T>(
 
   const onDragScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollPos.current = props.horizontal
-        ? event.nativeEvent.contentOffset.x
-        : event.nativeEvent.contentOffset.y;
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+
+      scrollPos.current = props.horizontal ? contentOffset.x : contentOffset.y;
+      flowScrollPos.current = isLayoutMirrored(props.horizontal)
+        ? contentSize.width - (contentOffset.x + layoutMeasurement.width)
+        : scrollPos.current;
       if (onScroll) {
         onScroll(event);
       }
@@ -842,10 +896,18 @@ function CellRendererComponent<T>(props: CellRendererProps<T>) {
       let target = 0;
 
       if (!isActive && layouts.hasOwnProperty(activeKey)) {
+        // How far a displaced neighbor travels to move one slot later in the
+        // data. Under a mirrored layout that direction is toward lower
+        // coordinates, and transforms aren't mirrored for us the way layout
+        // is, so the sign has to be applied by hand.
+        const slot = isLayoutMirrored(horizontal)
+          ? -layouts[activeKey].extent
+          : layouts[activeKey].extent;
+
         if (index >= hoverIndex && index <= activeIndex) {
-          target = layouts[activeKey].extent;
+          target = slot;
         } else if (index >= activeIndex && index <= hoverIndex) {
-          target = -layouts[activeKey].extent;
+          target = -slot;
         }
       }
       if (target === slideTargetRef.current) {


### PR DESCRIPTION
Fixes #121.

## What was wrong

Under RTL, Yoga mirrors a horizontal row, so an item's cached position **descends** as its index rises. Every position/index calculation assumed the opposite, which produced the reported symptom — a double-width gap that opens at the dragged item and never moves:

- **Hover index pinned at 0.** The scan starts at index 0 and advances while that item's far edge is behind the finger. Under RTL index 0 is the *rightmost* item, so the condition failed on the first iteration and the index never advanced. Every drop called `onReordered(from, 0)`.
- **Neighbors slid the wrong way.** With hover stuck at 0, every item between 0 and the active index took a positive displacement, moving away from the vacated slot rather than into it.

Auto-scroll turned out to be a second, independent bug in the same area. Under RTL `scrollToOffset` interprets its argument as an offset **counted from the start of the data** and converts it internally, while `onScroll` reports a plain cartesian `contentOffset`. Passing the cartesian value straight through made `VirtualizedList` mirror an already-mirrored number, so a one-item nudge threw the list most of its length and then ping-ponged between two positions.

## The fix

Position/index math now runs in *flow* order — increasing with the data — which coincides with coordinate order only when the layout isn't mirrored. A single `isLayoutMirrored()` predicate gates the hover scan, the slide direction, and the auto-scroll offset space, and the scroll position is tracked in both cartesian and data-relative form so each consumer gets the one it needs.

`inverted` is deliberately left alone. It mirrors at the render stage (a `scaleX`/`scaleY` transform Yoga never sees) rather than at the layout stage, so it flips the pointer-to-content mapping instead of the index ordering. That needs its own predicate and its own verification, and it's documented as unsupported.

## Test plan

- [x] 7 new unit tests covering mirrored hover tracking, drop index, slide direction, and auto-scroll offset space, each paired with a non-mirrored control. 5 fail if either half of the fix is reverted; suite is 37 passing.
- [x] Manual on Android (Pixel 9 Pro XL, API 35): RTL and LTR, drag reorder, gap tracking, auto-scroll off both edges, drop index verified against the printed data order.
- [x] Manual on iOS (iPhone 17 Pro Max, iOS 26.4): same cases.
- [x] Vertical lists unchanged in both directions.

The example app gains a direction toggle, a horizontal list long enough to auto-scroll, and a printed data order — the visual order mirrors under RTL, so it's the only way to distinguish a correct drop from one that landed at the mirrored index.

Note for reviewers reproducing this: on iOS the toggle's reload isn't enough for `forceRTL` to take effect. Relaunch natively with `xcrun simctl terminate` / `launch`.